### PR TITLE
Migrating from UA to new GA4 analytics

### DIFF
--- a/docs/assets/pages/contact.html
+++ b/docs/assets/pages/contact.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
+    function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-154658393-1');
+    gtag('config', 'G-0FMB6WDGXG');
   </script>
 
   <meta charset="UTF-8">

--- a/docs/assets/pages/drone.html
+++ b/docs/assets/pages/drone.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
+    function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-154658393-1');
+    gtag('config', 'G-0FMB6WDGXG');
   </script>
 
   <meta charset="UTF-8">

--- a/docs/assets/pages/projects/automaticWatering.html
+++ b/docs/assets/pages/projects/automaticWatering.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-154658393-1');
+        gtag('config', 'G-0FMB6WDGXG');
     </script>
 
     <meta charset="UTF-8">

--- a/docs/assets/pages/projects/ga.html
+++ b/docs/assets/pages/projects/ga.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-154658393-1');
+        gtag('config', 'G-0FMB6WDGXG');
     </script>
     
     <meta charset="utf-8" />

--- a/docs/assets/pages/projects/hydropatrol.html
+++ b/docs/assets/pages/projects/hydropatrol.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-154658393-1');
+        gtag('config', 'G-0FMB6WDGXG');
     </script>
 
     <meta charset="UTF-8">

--- a/docs/assets/pages/projects/orbit.html
+++ b/docs/assets/pages/projects/orbit.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-154658393-1');
+        gtag('config', 'G-0FMB6WDGXG');
     </script>
     
     <meta charset="UTF-8">

--- a/docs/assets/pages/projects/pong.html
+++ b/docs/assets/pages/projects/pong.html
@@ -2,14 +2,14 @@
 <html>
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-154658393-1');
+        gtag('config', 'G-0FMB6WDGXG');
     </script>
     
     <title>PONG GAME</title>

--- a/docs/assets/pages/projects/projects.html
+++ b/docs/assets/pages/projects/projects.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
+    function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-154658393-1');
+    gtag('config', 'G-0FMB6WDGXG');
   </script>
 
   <meta charset="UTF-8">

--- a/docs/assets/pages/projects/uw22_23.html
+++ b/docs/assets/pages/projects/uw22_23.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-154658393-1');
+        gtag('config', 'G-0FMB6WDGXG');
     </script>
 
     <meta charset="UTF-8">

--- a/docs/assets/pages/uw_cse455/quad_image.html
+++ b/docs/assets/pages/uw_cse455/quad_image.html
@@ -2,14 +2,14 @@
 <html lang="en">
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-154658393-1');
+        gtag('config', 'G-0FMB6WDGXG');
     </script>
 
     <meta charset="UTF-8">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,15 +2,16 @@
 <html lang="en">
 
 <head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-154658393-1"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0FMB6WDGXG"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
+    function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-154658393-1');
+    gtag('config', 'G-0FMB6WDGXG');
   </script>
+
   <script src="assets/cookie.js"></script>
 
   <meta charset="UTF-8">


### PR DESCRIPTION
The older universal analytics (UA) system by google analytics is being deprecated and replaced with google analytics 4 (GA4), hence the need to swap out the existing tags on all pages to preserve analytics.